### PR TITLE
Fix python3.10 warnings

### DIFF
--- a/src/ros_numpy/image.py
+++ b/src/ros_numpy/image.py
@@ -69,7 +69,7 @@ def image_to_numpy(msg):
 	dtype = dtype.newbyteorder('>' if msg.is_bigendian else '<')
 	shape = (msg.height, msg.width, channels)
 
-	data = np.fromstring(msg.data, dtype=dtype).reshape(shape)
+	data = np.frombuffer(msg.data, dtype=dtype).reshape(shape)
 	data.strides = (
 		msg.step,
 		dtype.itemsize * channels,
@@ -110,7 +110,7 @@ def numpy_to_image(arr, encoding):
 
 	# make the array contiguous in memory, as mostly required by the format
 	contig = np.ascontiguousarray(arr)
-	im.data = contig.tostring()
+	im.data = contig.tobytes()
 	im.step = contig.strides[0]
 	im.is_bigendian = (
 		arr.dtype.byteorder == '>' or 

--- a/src/ros_numpy/point_cloud2.py
+++ b/src/ros_numpy/point_cloud2.py
@@ -149,7 +149,7 @@ def array_to_pointcloud2(cloud_arr, stamp=None, frame_id=None):
     cloud_msg.point_step = cloud_arr.dtype.itemsize
     cloud_msg.row_step = cloud_msg.point_step*cloud_arr.shape[1]
     cloud_msg.is_dense = all([np.isfinite(cloud_arr[fname]).all() for fname in cloud_arr.dtype.names])
-    cloud_msg.data = cloud_arr.tostring()
+    cloud_msg.data = cloud_arr.tobytes()
     return cloud_msg
 
 def merge_rgb_fields(cloud_arr):
@@ -221,7 +221,7 @@ def split_rgb_field(cloud_arr):
             new_cloud_arr[field_name] = cloud_arr[field_name]
     return new_cloud_arr
 
-def get_xyz_points(cloud_array, remove_nans=True, dtype=np.float):
+def get_xyz_points(cloud_array, remove_nans=True, dtype=np.float64):
     '''Pulls out x, y, and z columns from the cloud recordarray, and returns
 	a 3xN matrix.
     '''

--- a/src/ros_numpy/registry.py
+++ b/src/ros_numpy/registry.py
@@ -27,7 +27,7 @@ def numpify(msg, *args, **kwargs):
 		return
 
 	conv = _to_numpy.get((msg.__class__, False))
-	if not conv and isinstance(msg, collections.Sequence):
+	if not conv and isinstance(msg, collections.abc.Sequence):
 		if not msg:
 			raise ValueError("Cannot determine the type of an empty Collection")
 		conv = _to_numpy.get((msg[0].__class__, True))

--- a/src/ros_numpy/transformations.py
+++ b/src/ros_numpy/transformations.py
@@ -29,7 +29,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-"""Homogeneous Transformation Matrices and Quaternions.
+r"""Homogeneous Transformation Matrices and Quaternions.
 A library for calculating 4x4 matrices for translating, rotating, reflecting,
 scaling, shearing, projecting, orthogonalizing, and superimposing arrays of
 3D homogeneous coordinates as well as for converting between rotation matrices,
@@ -788,7 +788,7 @@ def orthogonalization_matrix(lengths, angles):
 
 
 def superimposition_matrix(v0, v1, scaling=False, usesvd=True):
-    """Return matrix to transform given vector set into second vector set.
+    r"""Return matrix to transform given vector set into second vector set.
     v0 and v1 are shape (3, \*) or (4, \*) arrays of at least 3 vectors.
     If usesvd is True, the weighted sum of squared deviations (RMSD) is
     minimized according to the algorithm by W. Kabsch [8]. Otherwise the


### PR DESCRIPTION
This commit fixes warnings issued with Python3.10 when running the tests.

Edit: the change in registry.py is actually necessary for the code to execute properly with Python3.10.